### PR TITLE
vegan::adonis is deprecated & will be defunct: use vegan::adonis2

### DIFF
--- a/vignettes/betadiversity.Rmd
+++ b/vignettes/betadiversity.Rmd
@@ -244,14 +244,14 @@ PERMANOVA tests if the centroids, similar to means, of each group are significan
 Likewise, an $R^2$ statistic is calculated, showing the percentage of the variance explained by the groups.
 
 ```{r adonis}
-pathotype.adonis <- adonis(P_sojae_survey.matrix.jaccard ~ groups)
+pathotype.adonis <- adonis2(P_sojae_survey.matrix.jaccard ~ groups)
 
 pathotype.adonis
 ```
 
-The PERMANOVA identified no significant differences between the groups centroids, or means (*p* = `r pathotype.adonis[[1]][[6]][[1]]`).
+The PERMANOVA identified no significant differences between the groups centroids, or means (*p* = `r pathotype.adonis[[5]][[1]]`).
 In addition to identifying significance between group centroids, the PERMANOVA also calculates how much of the variance can be explained by the specified groups (see the $R^2$ column in the PERMANOVA output).
-In this case, the $R^2$ is `r pathotype.adonis[[1]][[6]][[1]]`, so `r round(pathotype.adonis[[1]][[6]][[1]], 3) * 100`% of the variance is explained by the groups used in analysis.
+In this case, the $R^2$ is `r pathotype.adonis[[3]][[1]]`, so `r round(pathotype.adonis[[3]][[1]], 3) * 100`% of the variance is explained by the groups used in analysis.
 Based on the PERMANOVA results we can conclude that these two groups are not different from each other and likely have similar pathotypes to each other.
 
 ## Analysis of Similarity (ANOSIM)


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Latest vegan release 2.6-6 in CRAN deprecates `vegan::adonis` in favour of `vegan::adonis2`, and our plan is to make `vegan::adonis` defunct in the future releases. Building your betadiversity vignette will give a warning with the latest vegan release and will give an error in the future releases (and already in the development version of vegan in github). The fix is obvious: use `vegan::adonis2`. The new `vegan::adonis2` has slightly different internal structure and instead of three list indices (like `[[1]][[6]][[1]]`) we now must use only two, and there is one column less (so the previous becomes `[[5]][[1]]`). NB., your original vignette used wrong index for $R^2$ pointing to the *p*-value. This is also fixed here. 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
